### PR TITLE
Add root as an action output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,11 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup OSGeo4W environment
+        id: setup-osgeo4w
         uses: ./
+      - name: Display all outputs as JSON
+        run: |
+          echo "${{ toJSON(steps.setup-osgeo4w.outputs) }}"
       - run: o-help
         shell: cmd /D /E:ON /V:OFF /S /C "CALL C:/OSGeo4W/OSGeo4W.bat "{0}""
   packages:
@@ -45,6 +49,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup OSGeo4W environment
+        id: setup-osgeo4w
         uses: ./
         with:
           # Using literal style to have multiline strings, and keeping a single final newline
@@ -67,6 +72,9 @@ jobs:
             python3-wxpython
             sqlite3-devel,\
             zstd-devel
+      - name: Display all outputs as JSON
+        run: |
+          echo "${{ toJSON(steps.setup-osgeo4w.outputs) }}"
       - run: o-help
         shell: cmd /D /E:ON /V:OFF /S /C "CALL C:/OSGeo4W/OSGeo4W.bat "{0}""
       - run: pip install pytest-timeout
@@ -97,6 +105,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup OSGeo4W environment
+        id: setup-osgeo4w
         uses: ./
         with:
           root: ${{ matrix.root-dir }}
@@ -106,6 +115,9 @@ jobs:
           packages: >-
             grass-dev
             saga
+      - name: Display all outputs as JSON
+        run: |
+          echo "${{ toJSON(steps.setup-osgeo4w.outputs) }}"
       - run: o-help
         shell: cmd /D /E:ON /V:OFF /S /C "CALL %TEST_O4W_ROOT%/OSGeo4W.bat "{0}""
       - run: pip install pytest-timeout

--- a/action.yml
+++ b/action.yml
@@ -30,10 +30,18 @@ inputs:
     description: Also upgrade installed packages
     required: false
     default: "true"
+
+outputs:
+  root:
+    description: >-
+      The root installation directory used.
+      Equivalent to the OSGEO4W_ROOT environment variable
+    value: ${{ steps.setup.outputs.root }}
 runs:
   using: "composite"
   steps:
     - name: Setup OSGeo4W environment
+      id: setup
       run: |-
         "Setup OSGeo4W environment action"
         . ${{ github.action_path }}/setup-osgeo4w.ps1

--- a/setup-osgeo4w.ps1
+++ b/setup-osgeo4w.ps1
@@ -58,27 +58,23 @@ Write-Output "$($PSStyle.Foreground.Blue)& $setup $args_ | Out-Default$($PSStyle
 Write-Output "::endgroup::"
 
 $root_Path = "$env:INPUT_ROOT"
-$root_Path
 if (!(Test-Path -Path $root_Path -PathType Container)) {
     Write-Output '::error title=Invalid root directory::The root directory does not exist after a successful installation.'
     exit 1
 }
 
 $osgeo4w_shell_Path = Join-Path -Path $root_Path -ChildPath 'OSGeo4W.bat' -Resolve
-$osgeo4w_shell_Path
 if (!(Test-Path -Path $osgeo4w_shell_Path -PathType Leaf)) {
     Write-Output "::error title=Missing OSGeo4W shell::The OSGeo4W.bat file used for the OSGeo4W shell isn't found after a successful installation."
     exit 1
 }
 
 $root_from_OSGeo4W = & $osgeo4w_shell_Path echo %OSGEO4W_ROOT%
-$root_from_OSGeo4W
 if (!(Test-Path -LiteralPath $root_from_OSGeo4W -PathType Container)) {
     Write-Output '::error title=Invalid root directory::The root directory returned by the OSGeo4W shell does not exist.'
     exit 1
 }
 $root_resolved = Resolve-Path -LiteralPath $root_from_OSGeo4W
-$root_resolved
 if (!(Test-Path -LiteralPath $root_resolved -PathType Container)) {
     Write-Output '::error title=Invalid root directory::The root directory returned by the OSGeo4W shell could not be resolved.'
     exit 1

--- a/setup-osgeo4w.ps1
+++ b/setup-osgeo4w.ps1
@@ -56,3 +56,13 @@ Write-Output "Setup executable is $setup"
 Write-Output "$($PSStyle.Foreground.Blue)& $setup $args_ | Out-Default$($PSStyle.Reset)"
 & $setup $args_ | Out-Default
 Write-Output "::endgroup::"
+
+$root_Path = "$env:INPUT_ROOT"
+$root_Path
+$root_PathValid = Test-Path -Path $root_Path -PathType Container
+$root_PathValid
+
+$osgeo4w_shell_Path = Join-Path -Path $root_Path -ChildPath "OSGeo4W.bat"
+$osgeo4w_shell_Path
+
+Write-Output "root=$($root_Path)" >> $Env:GITHUB_OUTPUT

--- a/setup-osgeo4w.ps1
+++ b/setup-osgeo4w.ps1
@@ -71,5 +71,18 @@ if (!(Test-Path -Path $osgeo4w_shell_Path -PathType Leaf)) {
     exit 1
 }
 
+$root_from_OSGeo4W = & $osgeo4w_shell_Path echo %OSGEO4W_ROOT%
+$root_from_OSGeo4W
+if (!(Test-Path -LiteralPath $root_from_OSGeo4W -PathType Container)) {
+    Write-Output '::error title=Invalid root directory::The root directory returned by the OSGeo4W shell does not exist.'
+    exit 1
+}
+$root_resolved = Resolve-Path -LiteralPath $root_from_OSGeo4W
+$root_resolved
+if (!(Test-Path -LiteralPath $root_resolved -PathType Container)) {
+    Write-Output '::error title=Invalid root directory::The root directory returned by the OSGeo4W shell could not be resolved.'
+    exit 1
+}
 
-Write-Output "root=$($root_Path)" >> $Env:GITHUB_OUTPUT
+Write-Output "root=$($root_resolved)" >> $Env:GITHUB_OUTPUT
+exit 0 

--- a/setup-osgeo4w.ps1
+++ b/setup-osgeo4w.ps1
@@ -59,10 +59,17 @@ Write-Output "::endgroup::"
 
 $root_Path = "$env:INPUT_ROOT"
 $root_Path
-$root_PathValid = Test-Path -Path $root_Path -PathType Container
-$root_PathValid
+if (!(Test-Path -Path $root_Path -PathType Container)) {
+    Write-Output '::error title=Invalid root directory::The root directory does not exist after a successful installation.'
+    exit 1
+}
 
-$osgeo4w_shell_Path = Join-Path -Path $root_Path -ChildPath "OSGeo4W.bat"
+$osgeo4w_shell_Path = Join-Path -Path $root_Path -ChildPath 'OSGeo4W.bat' -Resolve
 $osgeo4w_shell_Path
+if (!(Test-Path -Path $osgeo4w_shell_Path -PathType Leaf)) {
+    Write-Output "::error title=Missing OSGeo4W shell::The OSGeo4W.bat file used for the OSGeo4W shell isn't found after a successful installation."
+    exit 1
+}
+
 
 Write-Output "root=$($root_Path)" >> $Env:GITHUB_OUTPUT


### PR DESCRIPTION
Sets an action output parameter, named "root", to the value of the %OSGEO4W_ROOT% env var. Validates the folder given and the OSGeo4W shell file before using them, and checks if the returned value is a valid folder.