### PR TITLE
Replace deprecated windows-2019 image with windows-2025 in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-2019
           - windows-2022
+          - windows-2025
           - windows-latest
     steps:
       - name: Checkout Code
@@ -44,8 +44,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-2019
           - windows-2022
+          - windows-2025
           - windows-latest
     steps:
       - name: Checkout Code
@@ -93,8 +93,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-2019
           - windows-2022
+          - windows-2025
           - windows-latest
         root-dir:
           - "C:\\OSGeo4W"


### PR DESCRIPTION
The windows-2019 runner image is being removed at the end of June. Remove that image from the tested OSes, and add windows-2025 to test on the available images.